### PR TITLE
Bug Fix: Root verification failing although the element was in the set

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ In this approach we are commiting neccessary values and then proving them using 
  
  
  The Setmembership package contains the integration of all the above mentioned sub-protocols (Proving and Verifying).
-check.go gives an example of the flow.(Root verification may fail when values are not within bound defined by lamdas).
+check.go gives an example of the flow.
+If you want to change the bounds please modify the hard coded values in the root file. depending to what are your likings.
 
 ### Improvement required
 * Investigating the security of implemented  HashEq

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/marcoCalipari/Rsazkp
+module github.com/GarryFCR/Rsazkp
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/GarryFCR/Rsazkp
+module github.com/marcoCalipari/Rsazkp
 
 go 1.16

--- a/src/Hashtoprime/hash2prime.go
+++ b/src/Hashtoprime/hash2prime.go
@@ -53,7 +53,7 @@ func Hprime(u big.Int) big.Int {
 		prime := new(big.Int).Add(&temp, &j)
 
 		//temp.Add(&temp, &j)
-		if prime.ProbablyPrime(10) {
+		if prime.ProbablyPrime(500) {
 
 			return *prime
 		}

--- a/src/Root/root.go
+++ b/src/Root/root.go
@@ -1,6 +1,6 @@
 /*
-	The Root Protocol is the NIZK proof of a committed root of public RSA group element Acc
-	It takes an integer commitment to an element e and proves knowledge of an e-th root of Acc ie, W=Acc^(1/e) in zero knowledge
+The Root Protocol is the NIZK proof of a committed root of public RSA group element Acc
+It takes an integer commitment to an element e and proves knowledge of an e-th root of Acc ie, W=Acc^(1/e) in zero knowledge
 */
 package Root
 
@@ -15,21 +15,32 @@ import (
 	hash2prime "github.com/GarryFCR/Rsazkp/src/Hashtoprime"
 )
 
-func Generate_random(bound big.Int) big.Int {
+func Generate_random(bound big.Int, lambdas ...int64) big.Int {
+	var lambda int64
+	if len(lambdas) > 0 {
+		lambda = lambdas[0]
+	} else {
+		lambda = -1 // Indicates no lambda provided
+	}
 
 	upper := bound
-	lower := new(big.Int).Neg(&bound)
-
-	//rand.Seed(time.Now().UnixNano())
-	//n := a + rand.Intn(b-a+1)
+	lower := new(big.Int).Neg(&upper)
 
 	max := new(big.Int).Sub(&upper, lower)
 	max.Add(max, big.NewInt(1))
 
-	random, _ := rand.Int(rand.Reader, max)
-	random.Add(random, lower)
+	for {
+		random, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			panic("random number generation failed") // Handle error appropriately
+		}
+		random.Add(random, lower)
 
-	return *random
+		// Check if within lambda bounds, if lambda is provided
+		if lambda == -1 || isWithinLambda(random, lambda) {
+			return *random
+		}
+	}
 }
 
 func Generate_s(a, b, c big.Int) big.Int {
@@ -95,30 +106,24 @@ func Prove(crs, commitment, witness []big.Int, lambda_s, lambda_z, mu int64) []b
 	bound := *new(big.Int).Div(&N, big.NewInt(4))
 
 	r2 := Generate_random(*new(big.Int).Sub(&bound, big.NewInt(1)))
+
 	r3 := Generate_random(*new(big.Int).Sub(&bound, big.NewInt(1)))
 
 	Cw := Generate_alpha(W, H, N, *big.NewInt(1), r2)
 	Cr := Generate_alpha(G, H, N, r2, r3)
 
-	bound1 := big.NewInt(2)
-	bound1.Exp(bound1, big.NewInt(lambda_s+lambda_z+mu), nil)
-	re := Generate_random(*bound1)
+	boundLambdaMu := new(big.Int).Exp(big.NewInt(2), big.NewInt(lambda_s+lambda_z+mu), nil)
+	boundLambda := new(big.Int).Exp(big.NewInt(2), big.NewInt(lambda_s+lambda_z), nil)
+	boundLambda.Mul(boundLambda, &bound).Sub(boundLambda, big.NewInt(1))
+	boundLambdaMuSpecial := boundLambdaMu.Mul(boundLambdaMu, &bound)
 
-	bound2 := big.NewInt(2)
-	bound2.Exp(bound2, big.NewInt(lambda_s+lambda_z), nil)
-	bound2.Mul(&bound, bound2)
-	bound2.Sub(bound2, big.NewInt(1))
-	rr := Generate_random(*bound2)
-	rr2 := Generate_random(*bound2)
-	rr3 := Generate_random(*bound2)
-
-	bound3 := big.NewInt(2)
-	bound3.Exp(bound3, big.NewInt(lambda_s+lambda_z+mu), nil)
-	bound3.Mul(&bound, bound3)
-	bound3.Sub(bound3, big.NewInt(1))
-	r_beta := Generate_random(*bound3)
-	r_delta := Generate_random(*bound3)
-	//fmt.Println("GHNRERR:", G, H, N, re, rr)
+	// Generate random numbers within lambda bounds
+	re := Generate_random(*boundLambdaMu, lambda_s+lambda_z+mu)
+	rr := Generate_random(*boundLambda, lambda_s+lambda_z)
+	rr2 := Generate_random(*boundLambda, lambda_s+lambda_z)
+	rr3 := Generate_random(*boundLambda, lambda_s+lambda_z)
+	r_beta := Generate_random(*boundLambdaMuSpecial, lambda_s+lambda_z+mu)
+	r_delta := Generate_random(*boundLambdaMuSpecial, (lambda_s + lambda_z + mu))
 
 	alpha1 := Generate_alpha(G, H, N, re, rr)
 	alpha2 := Generate_alpha(G, H, N, rr2, rr3)
@@ -203,4 +208,10 @@ func VerProof(crs, commitment, pi []big.Int, lambda, lambda_s, mu int64) int {
 
 	return 0
 
+}
+
+func isWithinLambda(value *big.Int, lambda int64) bool {
+	bound := big.NewInt(1)         // 2^0 = 1
+	bound.Lsh(bound, uint(lambda)) // 2^lambda
+	return value.Cmp(bound) == -1  // check if value < 2^lambda
 }

--- a/src/SetMembership/setmember.go
+++ b/src/SetMembership/setmember.go
@@ -48,7 +48,6 @@ func Prove(crs, U []big.Int, Cu, cu, u, ru big.Int) (Ce, ce big.Int, proof_root,
 	}
 
 	W := G
-
 	commit := []big.Int{Ce, Cu}
 	root_witness := []big.Int{e, r, W}
 	pi_root := root.Prove(crs[:3], commit, root_witness, int64(512), int64(512), int64(512))

--- a/src/SetMembership/setmember.go
+++ b/src/SetMembership/setmember.go
@@ -51,7 +51,7 @@ func Prove(crs, U []big.Int, Cu, cu, u, ru big.Int) (Ce, ce big.Int, proof_root,
 
 	commit := []big.Int{Ce, Cu}
 	root_witness := []big.Int{e, r, W}
-	pi_root := root.Prove(crs[:3], commit, root_witness, int64(256), int64(256), int64(512))
+	pi_root := root.Prove(crs[:3], commit, root_witness, int64(512), int64(512), int64(512))
 
 	commit1 := []big.Int{Ce, ce}
 	mod_witness := []big.Int{e, e, r, rq}

--- a/src/Setup/pedersen.go
+++ b/src/Setup/pedersen.go
@@ -32,7 +32,7 @@ func Pedersen_setup(lambda, nu int64) (x, y, z big.Int) {
 		}
 		fmt.Println(prime, prime_bound1.Sign(), prime_bound2.Sign())
 	}
-	//fmt.Println(prime)
+
 	g, _ := rand.Int(rand.Reader, prime)
 	h, _ := rand.Int(rand.Reader, prime)
 	//fmt.Println(prime, g, h)

--- a/src/check.go
+++ b/src/check.go
@@ -14,58 +14,50 @@ func main() {
 	//PEDERSEN COMMITMENT----------------------------------------------------
 	prime, g, h := setup.Pedersen_setup(512, 512)
 	ck_pedersen := []big.Int{prime, g, h}
-	u := big.NewInt(12345)
+	u := big.NewInt(10000011)
 
 	cu, ru := setup.Pedersen_commit(ck_pedersen, prime, *u)
-
-	ver := setup.Pedersen_ver(ck_pedersen, cu, *u, ru)
-	fmt.Println("--------------Commiting a set-member--------------")
-	if ver == 1 {
-		fmt.Println("Pedersen:Commitment VERIFIED")
-	} else {
-		fmt.Println("Pedersen verification failed")
-
-	}
 
 	//SET COMMITMENT----------------------------------------------------------
 	N, G := setup.Set_setup(512, 512)
 
 	ck_set := []big.Int{N, G}
-	set := []big.Int{*big.NewInt(12342), *big.NewInt(12343), *big.NewInt(12344), *big.NewInt(12345)}
+	set := []big.Int{*big.NewInt(10000001), *big.NewInt(10000002),
+		*big.NewInt(10000003), *big.NewInt(10000000), *big.NewInt(10000011)}
 
 	Acc, _ := setup.Set_commit(ck_set, set)
-
-	ver1 := setup.Set_ver(ck_set, set, Acc)
-	fmt.Println()
-	fmt.Println("-------------------Commiting the set--------------")
-	if ver1 == 1 {
-		fmt.Println("Set commit:Commitment VERIFIED")
-	} else {
-		fmt.Println("Set verification failed")
-
-	}
 
 	//SETMEMBERSHIP------------------------------------------------------------
 	//KEYGEN-------------------------------------------------------------------
 	ck_key := []big.Int{N, G, prime, g, h}
-	fmt.Println()
-	fmt.Println("Generating key for protocol...")
 	crs := member.KeyGen(ck_key)
 
 	//PROVE--------------------------------------------------------------------
 	fmt.Println()
-	fmt.Println("---------------------Proving----------------------")
 
-	Ce, ce, pi_root, pi_mod, pi_hash := member.Prove(crs, set, Acc, cu, *u, ru)
-	fmt.Println("Proof generated")
 	//VERIFICATION--------------------------------------------------------------
+	var correct int
+	var wrong int
+	var iter = 10
+	fmt.Println("Computing")
+	for i := 0; i < iter; i++ {
+		Ce, ce, pi_root, pi_mod, pi_hash := member.Prove(crs, set, Acc, cu, *u, ru)
+		BOOL := member.VerProof(crs, Acc, cu, Ce, ce, pi_root, pi_mod, pi_hash)
+		if BOOL == 1 {
 
-	BOOL := member.VerProof(crs, Acc, cu, Ce, ce, pi_root, pi_mod, pi_hash)
-	fmt.Println("---------------------Verification-----------------")
-	if BOOL == 1 {
-		fmt.Println("Verified")
-	} else {
-		fmt.Println("Verification failed")
+			correct++
+		} else {
+
+			wrong++
+		}
 	}
+
+	// Convert to float64 for accurate percentage calculation
+	fmt.Println("Done")
+	correctPercentage := (float64(correct) / float64(iter)) * 100
+	wrongPercentage := (float64(wrong) / float64(iter)) * 100
+
+	fmt.Printf("Probability of correct: %.2f%%\n", correctPercentage)
+	fmt.Printf("Probability of wrong: %.2f%%\n", wrongPercentage)
 
 }


### PR DESCRIPTION
With this version, I fixed the bug related to the CP_root algorithm that would occasionally fail if the number was outside the bound of the security parameters lambda_z, lambda_s, or mu.

With a modification in the `GenerateRandom(...)` function, generating random numbers within the correct bounds is now possible. In this way, we have deterministic behavior in the code. 